### PR TITLE
fix: reconnect to Jetstream with exponential backoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Repository Guidelines
+
+- All commits must use the [Conventional Commits](https://www.conventionalcommits.org/) specification for their messages.

--- a/src/jetstream.mts
+++ b/src/jetstream.mts
@@ -5,8 +5,49 @@ export const jetstream = new Jetstream({
   wantedCollections: ['app.bsky.graph.block', 'app.bsky.graph.listitem', 'app.bsky.feed.post'],
 });
 
+const BASE_RECONNECT_DELAY_MS = 1_000;
+const MAX_RECONNECT_DELAY_MS = 60_000;
+let reconnectAttempts = 0;
+let reconnectTimeout: ReturnType<typeof setTimeout> | undefined;
+
+const clearScheduledReconnect = () => {
+  if (reconnectTimeout) {
+    clearTimeout(reconnectTimeout);
+    reconnectTimeout = undefined;
+  }
+};
+
+const scheduleReconnect = () => {
+  if (reconnectTimeout) return;
+
+  const delay = Math.min(
+    BASE_RECONNECT_DELAY_MS * 2 ** reconnectAttempts,
+    MAX_RECONNECT_DELAY_MS,
+  );
+  reconnectAttempts += 1;
+
+  console.warn(`Jetstream connection lost. Reconnecting in ${delay}ms.`);
+  reconnectTimeout = setTimeout(() => {
+    reconnectTimeout = undefined;
+    jetstream.start();
+  }, delay);
+};
+
 jetstream.on('app.bsky.graph.block', jetstreamBlockHandler);
 
 jetstream.on('app.bsky.graph.listitem', jetstreamListItemHandler);
 
 jetstream.on('app.bsky.feed.post', jetstreamFeedPostHandler);
+
+jetstream.on('open', () => {
+  reconnectAttempts = 0;
+  clearScheduledReconnect();
+});
+
+jetstream.on('close', scheduleReconnect);
+
+jetstream.on('error', (error: unknown) => {
+  console.error('Jetstream encountered an error. Attempting to reconnect.', error);
+  jetstream.close();
+  scheduleReconnect();
+});


### PR DESCRIPTION
## Summary
- add exponential backoff reconnection logic for the Jetstream client when errors or closures occur
- reset the backoff timer once the stream reconnects successfully

## Testing
- npm test *(fails: network access is blocked in the execution environment, causing handle resolution to fail)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a809b4f8832b9dbaab9970473f91