### PR TITLE
Improve bot error logging readability

### DIFF
--- a/src/bot-handlers.mts
+++ b/src/bot-handlers.mts
@@ -17,6 +17,33 @@ export const chatMessageHandler = async (message: ChatMessage) => {
   }
 };
 
+type XrpcErrorLike = {
+  status?: number;
+  kind?: string;
+  description?: string;
+};
+
+const formatErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (error && typeof error === 'object') {
+    const { status, kind, description } = error as XrpcErrorLike;
+    const parts = [
+      typeof status === 'number' ? `status ${status}` : undefined,
+      kind,
+      description,
+    ].filter((part): part is string => Boolean(part));
+
+    if (parts.length) {
+      return parts.join(' – ');
+    }
+  }
+
+  return String(error);
+};
+
 export const chatErrorHandler = async (error: unknown) => {
-  console.error('Bot error:', error instanceof Error ? error : new Error(String(error)));
+  console.error(`Bot error: ${formatErrorMessage(error)}`);
 };

--- a/src/bot-handlers.test.mts
+++ b/src/bot-handlers.test.mts
@@ -1,7 +1,11 @@
-import { test, expect } from 'vitest';
-import { chatMessageHandler } from './bot-handlers.mts';
+import { afterEach, expect, test, vi } from 'vitest';
+import { chatErrorHandler, chatMessageHandler } from './bot-handlers.mts';
 import { ChatMessage } from '@skyware/bot';
 import { outdent } from 'outdent';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 test('chatMessageHandler', async () => {
   let reply = '';
@@ -31,4 +35,24 @@ test('chatMessageHandler', async () => {
     - 'hide all': Turn off all notifications
     - 'settings': View your current notification settings
   `);
+});
+
+test('chatErrorHandler formats XRPC errors', async () => {
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+  await chatErrorHandler({
+    status: 502,
+    kind: 'UpstreamFailure',
+    description: 'UpstreamFailure',
+  });
+
+  expect(consoleError).toHaveBeenCalledWith('Bot error: status 502 – UpstreamFailure – UpstreamFailure');
+});
+
+test('chatErrorHandler falls back to generic errors', async () => {
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+  await chatErrorHandler(new Error('Unexpected failure'));
+
+  expect(consoleError).toHaveBeenCalledWith('Bot error: Unexpected failure');
 });


### PR DESCRIPTION
## Summary
- format bot error logs to provide concise status, kind, and description details for XRPC errors
- add tests covering the improved logging and preserving existing chat message handling

## Testing
- npm test *(fails: fetch failures in existing tests due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d7acce0048832bb3b3d6f2b077d045