### PR TITLE
fix: logs on a single line

### DIFF
--- a/src/bot-handlers.mts
+++ b/src/bot-handlers.mts
@@ -1,10 +1,11 @@
 import { ChatMessage } from '@skyware/bot';
 import { createReply } from './common/create-reply.mts';
+import { logger } from './logger.mts';
 
 export const chatMessageHandler = async (message: ChatMessage) => {
   try {
     const sender = await message.getSender();
-    console.log(`Received message from @${sender.handle}: ${message.text}`);
+    logger.info(`Received message from @${sender.handle}: ${message.text}`);
 
     const conversation = await message.getConversation();
     if (!conversation) return;
@@ -13,10 +14,10 @@ export const chatMessageHandler = async (message: ChatMessage) => {
       text: await createReply(sender, message),
     });
   } catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 };
 
 export const chatErrorHandler = async (error: unknown) => {
-  console.error('Bot error:', error instanceof Error ? error : new Error(String(error)));
+  logger.error('Bot error:', error instanceof Error ? error : new Error(String(error)));
 };

--- a/src/cache.mts
+++ b/src/cache.mts
@@ -1,6 +1,7 @@
 import { ListView } from '@atproto/api/dist/client/types/app/bsky/graph/defs.js';
 import { TimeCache } from './time-cache.mts';
 import { publicAgent, authedAgent } from './common/agents.mts';
+import { logger } from './logger.mts';
 
 const ONE_MINUTE = 60_000;
 
@@ -63,17 +64,17 @@ export const resolveHandleToDid = async (_handle: string) => {
     const cachedDid = didCache.get(handle);
     if (cachedDid) return cachedDid;
 
-    console.info(`Fetching profile for ${handle}`);
+    logger.info(`Fetching profile for ${handle}`);
     const did = await fetch(`https://bsky.social/xrpc/com.atproto.identity.resolveHandle?handle=${handle}`)
       .then((res) => res.json())
       .then((data) => data.did);
     didCache.set(handle, did);
 
-    console.info(`Resolved ${handle} to ${did}`);
+    logger.info(`Resolved ${handle} to ${did}`);
 
     return did;
   } catch (error) {
-    console.error('Failed to resolve handle to DID:', error);
+    logger.error('Failed to resolve handle to DID:', error);
     return null;
   }
 };

--- a/src/common/create-reply.mts
+++ b/src/common/create-reply.mts
@@ -2,10 +2,7 @@ import { Profile, ChatMessage } from '@skyware/bot';
 import { db } from '../db/index.mts';
 import { resolveDidToHandle, resolveHandleToDid } from '../cache.mts';
 import { outdent } from 'outdent';
-
-function bigIntReplacer(_key: string, value: any): any {
-  return typeof value === 'bigint' ? value.toString() : value;
-}
+import { logger } from '../logger.mts';
 
 export const createReply = async (sender: Profile, message: ChatMessage) => {
   const [command = '', subCommand = '', ...props] = message.text.toLowerCase().split(' ');
@@ -33,7 +30,7 @@ export const createReply = async (sender: Profile, message: ChatMessage) => {
         .values({ did: sender.did, blocks: 1, lists: 0 })
         .onConflict((builder) => builder.doUpdateSet({ blocks: 1 }))
         .executeTakeFirst();
-      console.info(`Updated settings for ${sender.did}: ${JSON.stringify(result, bigIntReplacer)}`);
+      logger.info(`Updated settings for ${sender.did}`, result);
       return "You'll now receive notifications when someone blocks you.";
     }
     case 'notify lists': {
@@ -42,7 +39,7 @@ export const createReply = async (sender: Profile, message: ChatMessage) => {
         .values({ did: sender.did, blocks: 0, lists: 1 })
         .onConflict((builder) => builder.doUpdateSet({ lists: 1 }))
         .executeTakeFirst();
-      console.info(`Updated settings for ${sender.did}: ${JSON.stringify(result, bigIntReplacer)}`);
+      logger.info(`Updated settings for ${sender.did}`, result);
       return "You'll now receive notifications when you're added to lists.";
     }
     case 'notify all': {
@@ -51,7 +48,7 @@ export const createReply = async (sender: Profile, message: ChatMessage) => {
         .values({ did: sender.did, blocks: 1, lists: 1 })
         .onConflict((builder) => builder.doUpdateSet({ blocks: 1, lists: 1 }))
         .executeTakeFirst();
-      console.info(`Updated settings for ${sender.did}: ${JSON.stringify(result, bigIntReplacer)}`);
+      logger.info(`Updated settings for ${sender.did}`, result);
       return "You'll now receive all notifications.";
     }
     case 'notify posts': {
@@ -67,17 +64,17 @@ export const createReply = async (sender: Profile, message: ChatMessage) => {
         .onConflict((builder) => builder.doUpdateSet({ from: from }))
         .executeTakeFirst();
 
-      console.info(`Updated post notifications for ${sender.did}: ${JSON.stringify(result, bigIntReplacer)}`);
+      logger.info(`Updated post notifications for ${sender.did}`, result);
       return `You will be notified when ${handle} makes a post.`;
     }
     case 'hide blocks': {
       const result = await db.updateTable('settings').set({ blocks: 0 }).where('did', '=', sender.did).executeTakeFirst();
-      console.info(`Deleted settings for ${sender.did}: ${JSON.stringify(result, bigIntReplacer)}`);
+      logger.info(`Deleted settings for ${sender.did}`, result);
       return "You'll no longer receive block notifications.";
     }
     case 'hide lists': {
       const result = await db.updateTable('settings').set({ lists: 0 }).where('did', '=', sender.did).executeTakeFirst();
-      console.info(`Deleted settings for ${sender.did}: ${JSON.stringify(result, bigIntReplacer)}`);
+      logger.info(`Deleted settings for ${sender.did}`, result);
       return "You'll no longer receive list notifications.";
     }
     case 'hide posts': {
@@ -92,24 +89,24 @@ export const createReply = async (sender: Profile, message: ChatMessage) => {
         .where('did', '=', sender.did)
         .where('from', '=', from)
         .executeTakeFirst();
-      console.info(`Deleted post notifications for ${sender.did}: ${JSON.stringify(result, bigIntReplacer)}`);
+      logger.info(`Deleted post notifications for ${sender.did}`, result);
       return `You will no longer be notified when ${handle} makes a post.`;
     }
     case 'hide all': {
       const result = await db.deleteFrom('settings').where('did', '=', sender.did).executeTakeFirst();
-      console.info(`Updated settings for ${sender.did}: ${JSON.stringify(result, bigIntReplacer)}`);
+      logger.info(`Updated settings for ${sender.did}`, result);
       return "You'll no longer receive any notifications.";
     }
     case 'settings': {
       const settings = await db.selectFrom('settings').selectAll().where('did', '=', sender.did).executeTakeFirst();
-      console.info(`Got settings for ${sender.did}: ${JSON.stringify(settings, bigIntReplacer)}`);
+      logger.info(`Got settings for ${sender.did}`, settings);
 
       const postNotifications = await db
         .selectFrom('post_notifications')
         .selectAll()
         .where('did', '=', sender.did)
         .execute();
-      console.info(`Got post notifications for ${sender.did}: ${JSON.stringify(postNotifications, bigIntReplacer)}`);
+      logger.info(`Got post notifications for ${sender.did}`, postNotifications);
 
       const handles = await Promise.all(
         postNotifications.map(async (notification) => resolveDidToHandle(notification.from)),

--- a/src/common/process-queue.mts
+++ b/src/common/process-queue.mts
@@ -1,5 +1,6 @@
 import { bot } from '../bot.mts';
 import { getMessages, getQueueNames, messagesToRichText } from '../queue.mts';
+import { logger } from '../logger.mts';
 
 export const processQueue = async () => {
   const queues = getQueueNames();
@@ -11,14 +12,14 @@ export const processQueue = async () => {
   for (const queue of queues) {
     const messages = getMessages(queue);
     if (messages.length === 0) continue;
-    console.info(`Sending ${messages.length} messages for queue ${queue}`);
+    logger.info(`Sending ${messages.length} messages for queue ${queue}`);
 
     for (const message of messages) {
       try {
         const conversation = await bot.getConversationForMembers([queue]);
         await conversation.sendMessage({ text: await messagesToRichText([message]) });
       } catch (error) {
-        console.error(`Failed to send message to ${queue}:`, error);
+        logger.error(`Failed to send message to ${queue}:`, error);
       }
     }
   }

--- a/src/index.mts
+++ b/src/index.mts
@@ -5,6 +5,7 @@ import { jetstream } from './jetstream.mts';
 import { db, migrateToLatest } from './db/index.mts';
 import { processQueue } from './common/process-queue.mts';
 import { updateBio } from './common/update-bio.mts';
+import { logger } from './logger.mts';
 
 const username = process.env.BSKY_USERNAME;
 const password = process.env.BSKY_PASSWORD;
@@ -14,7 +15,7 @@ const TEN_MINUTES = 600_000;
 
 const main = async () => {
   if (!username || !password) {
-    console.error('Please provide a username and password in the environment variables BSKY_USERNAME and BSKY_PASSWORD.');
+    logger.error('Please provide a username and password in the environment variables BSKY_USERNAME and BSKY_PASSWORD.');
     process.exit(1);
   }
 
@@ -25,11 +26,11 @@ const main = async () => {
     password,
   });
 
-  console.info(`Logged in as ${username}`);
+  logger.info(`Logged in as ${username}`);
 
   await bot.setChatPreference(IncomingChatPreference.All);
 
-  console.info('Listening for messages...');
+  logger.info('Listening for messages...');
 
   jetstream.start();
 
@@ -37,4 +38,6 @@ const main = async () => {
   setTimeout(updateBio, TEN_MINUTES);
 };
 
-main().catch(console.error);
+main().catch((error) => {
+  logger.error(error);
+});

--- a/src/jetstream-handlers.mts
+++ b/src/jetstream-handlers.mts
@@ -1,6 +1,7 @@
 import { CommitEvent } from '@skyware/jetstream';
 import { addMessage } from './queue.mts';
 import { db } from './db/index.mts';
+import { logger } from './logger.mts';
 
 export const jetstreamBlockHandler = async (event: CommitEvent<'app.bsky.graph.block'>) => {
   try {
@@ -22,7 +23,7 @@ export const jetstreamBlockHandler = async (event: CommitEvent<'app.bsky.graph.b
       did: did,
     });
   } catch (error) {
-    console.error('Failed to process block event:', error);
+    logger.error('Failed to process block event:', error);
   }
 };
 
@@ -47,7 +48,7 @@ export const jetstreamListItemHandler = async (event: CommitEvent<'app.bsky.grap
       did,
     });
   } catch (error) {
-    console.error('Failed to process list event:', error);
+    logger.error('Failed to process list event:', error);
   }
 };
 
@@ -77,6 +78,6 @@ export const jetstreamFeedPostHandler = async (event: CommitEvent<'app.bsky.feed
       });
     }
   } catch (error) {
-    console.error('Failed to process post event:', error);
+    logger.error('Failed to process post event:', error);
   }
 };

--- a/src/logger.mts
+++ b/src/logger.mts
@@ -1,0 +1,51 @@
+import util from 'node:util';
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+const sanitizeWhitespace = (value: string): string => {
+  if (!isProduction) {
+    return value;
+  }
+
+  return value.replace(/\s*\n\s*/g, ' | ');
+};
+
+const formatArgument = (arg: unknown): string => {
+  if (typeof arg === 'string') {
+    return sanitizeWhitespace(arg);
+  }
+
+  if (arg instanceof Error) {
+    const representation = arg.stack ?? `${arg.name}: ${arg.message}`;
+    return sanitizeWhitespace(representation);
+  }
+
+  if (typeof arg === 'object' && arg !== null) {
+    const representation = util.inspect(arg, { depth: null, breakLength: Infinity });
+    return sanitizeWhitespace(representation);
+  }
+
+  return sanitizeWhitespace(String(arg));
+};
+
+const format = (args: unknown[]): string => args.map(formatArgument).join(' ');
+
+export const logger = {
+  info: (...args: unknown[]): void => {
+    console.info(format(args));
+  },
+  error: (...args: unknown[]): void => {
+    console.error(format(args));
+  },
+  warn: (...args: unknown[]): void => {
+    console.warn(format(args));
+  },
+  debug: (...args: unknown[]): void => {
+    console.debug(format(args));
+  },
+  log: (...args: unknown[]): void => {
+    console.log(format(args));
+  },
+} as const;
+
+export type Logger = typeof logger;

--- a/src/queue.mts
+++ b/src/queue.mts
@@ -1,5 +1,6 @@
 import { ListPurpose, RichText } from '@skyware/bot';
 import { resolveDidToHandle, fetchListDetails } from './cache.mts';
+import { logger } from './logger.mts';
 
 type BlockedMessage = {
   /**
@@ -107,7 +108,7 @@ export const getMessages = (queueName: string): Message[] => {
 };
 
 export const addMessage = (queueName: string, message: Message) => {
-  console.info(`Adding message to queue ${queueName}: ${message.type}`);
+  logger.info(`Adding message to queue ${queueName}: ${message.type}`);
   const messages = queue.get(queueName) || new Set();
   messages.add(message);
   queue.set(queueName, messages);


### PR DESCRIPTION
## Summary
- add a reusable logger that collapses newlines when NODE_ENV=production
- replace direct console logging across handlers and the entrypoint to use the shared logger
- log reply settings updates with structured context arguments instead of JSON-stringified message payloads

## Testing
- npm test *(fails: fetch calls to Bluesky endpoints are blocked in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ad0769a8832baf2517694cdfa924