### PR TITLE
fix: queue message deduplication

### DIFF
--- a/src/queue.mts
+++ b/src/queue.mts
@@ -95,21 +95,34 @@ export const messagesToRichText = async (messages: Message[]): Promise<RichText>
   return richText;
 };
 
-const queue = new Map<string, Set<Message>>();
+const queue = new Map<string, Map<string, Message>>();
+
+const resolveMessageKey = (message: Message): string => {
+  switch (message.type) {
+    case 'blocked':
+      return `${message.type}:${message.did}`;
+    case 'list':
+      return `${message.type}:${message.did}:${message.list}`;
+    case 'post':
+      return `${message.type}:${message.did}:${message.post}`;
+  }
+};
 
 export const getQueueNames = (): string[] => {
   return Array.from(queue.keys());
 };
 
 export const getMessages = (queueName: string): Message[] => {
-  const messages = queue.get(queueName) || [];
-  queue.set(queueName, new Set());
+  const messages = queue.get(queueName);
+  if (!messages) return [];
+
+  queue.set(queueName, new Map());
   return [...messages.values()];
 };
 
 export const addMessage = (queueName: string, message: Message) => {
   logger.info(`Adding message to queue ${queueName}: ${message.type}`);
-  const messages = queue.get(queueName) || new Set();
-  messages.add(message);
+  const messages = queue.get(queueName) || new Map();
+  messages.set(resolveMessageKey(message), message);
   queue.set(queueName, messages);
 };

--- a/src/queue.test.mts
+++ b/src/queue.test.mts
@@ -1,6 +1,24 @@
-import { messagesToRichText } from './queue.mts';
+import { expect, test, vi } from 'vitest';
 import outdent from 'outdent';
-import { test, expect } from 'vitest';
+
+vi.mock('./cache.mts', () => ({
+  resolveDidToHandle: vi.fn(async (did: string) => {
+    switch (did) {
+      case 'did:plc:k6acu4chiwkixvdedcmdgmal':
+        return 'imlunahey.com';
+      case 'did:web:safety.lukeacl.com':
+        return 'safety.lukeacl.com';
+      default:
+        return did;
+    }
+  }),
+  fetchListDetails: vi.fn(async () => ({
+    name: 'fake accounts',
+    purpose: 'app.bsky.graph.defs#modlist',
+  })),
+}));
+
+import { addMessage, getMessages, messagesToRichText } from './queue.mts';
 
 test('converting messages to rich text', async () => {
   const richText = await messagesToRichText([
@@ -25,4 +43,28 @@ test('converting messages to rich text', async () => {
     You were blocked by safety.lukeacl.com
     imlunahey.com has added you to the "fake accounts" moderation list.
   `);
+});
+
+test('adding duplicate messages only keeps the latest instance', () => {
+  const queueName = 'did:plc:a3awelxrffaersstz2u3ksjt';
+
+  const firstMessage = {
+    type: 'list' as const,
+    did: 'did:plc:a3awelxrffaersstz2u3ksjt',
+    list: '3lh7m34kh672k',
+  };
+
+  const secondMessage = {
+    type: 'list' as const,
+    did: 'did:plc:a3awelxrffaersstz2u3ksjt',
+    list: '3lh7m34kh672k',
+  };
+
+  addMessage(queueName, firstMessage);
+  addMessage(queueName, secondMessage);
+
+  const messages = getMessages(queueName);
+
+  expect(messages).toHaveLength(1);
+  expect(messages[0]).toStrictEqual(secondMessage);
 });


### PR DESCRIPTION
## Summary
- ensure queued messages are keyed so identical payloads are deduplicated
- mock cache lookups in queue tests and add coverage for duplicate messages

## Testing
- npm test -- queue

------
https://chatgpt.com/codex/tasks/task_e_68d7e0b1ca3c832b95c39e16fa716be0